### PR TITLE
Small fixes to data generation

### DIFF
--- a/lib/engines/backToTheFuture.js
+++ b/lib/engines/backToTheFuture.js
@@ -42,7 +42,7 @@ B2TFEngine.prototype.generateData = function(system) {
     try {
         _.times(this.getDaysInPast(), function(day) {
             console.log("Day #", day);
-            var currentDay = moment().subtract(day, "days").hours(0).minutes(0).seconds(0);
+            var currentDay = moment().subtract(self.getDaysInPast() - day, "days").hours(0).minutes(0).seconds(0);
 
             _.times(self.getValuesPerDay(), function(nthValue) {
                 var timeOfDay = currentDay.add(minutesOffset, "minutes");

--- a/lib/generators/increment.js
+++ b/lib/generators/increment.js
@@ -5,7 +5,7 @@ function IncrementGenerator(options) {
 }
 
 IncrementGenerator.prototype.generate = function() {
-    if (!this.lastValue) {
+    if (this.lastValue === null) {
         this.lastValue = this.initialValue;
     } else {
         this.lastValue = this.lastValue + this.step;


### PR DESCRIPTION
I fixed two things:
- A null test that made the incremental generator always generate the first value.
- The loop order for generating old data: it used to start today and move backwards in time. This messed with some generators (like theincremental one). It now starts on the oldest day and moves forward in time.
